### PR TITLE
gradle: further product flavor improvements

### DIFF
--- a/VRHackathons/VRBasketBalls/VRBasketBallsAndroid/AndroidManifest.xml
+++ b/VRHackathons/VRBasketBalls/VRBasketBallsAndroid/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.cesarandres.vr.vrbbals.android.MainActivity"
             android:screenOrientation="reverseLandscape"

--- a/VRHackathons/VRTransit/AndroidManifest.xml
+++ b/VRHackathons/VRTransit/AndroidManifest.xml
@@ -27,7 +27,7 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name=".MainActivity"
             android:screenOrientation="landscape"

--- a/VRHackathons/bondage/app/src/main/AndroidManifest.xml
+++ b/VRHackathons/bondage/app/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
         android:icon="@drawable/icon"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.bondage.BondageActivity"
             android:screenOrientation="landscape"

--- a/VRHackathons/oVeREater/app/src/main/AndroidManifest.xml
+++ b/VRHackathons/oVeREater/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name=".FEMainActivity"
             android:label="@string/app_name" >

--- a/VRHackathons/sxr-VRGallery/sxr360photo/src/main/AndroidManifest.xml
+++ b/VRHackathons/sxr-VRGallery/sxr360photo/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
                    android:icon="@drawable/ic_launcher"
                    android:theme="@style/AppTheme" >
 
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity android:name="Minimal360PhotoActivity"
                   android:screenOrientation="landscape"
                   android:launchMode="singleTask"

--- a/VRHackathons/sxr-pokemon/app/src/main/AndroidManifest.xml
+++ b/VRHackathons/sxr-pokemon/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
         android:icon="@drawable/icon"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.balloons.BalloonActivity"
             android:screenOrientation="landscape"

--- a/VRHackathons/sxr-sociobowl/app/src/main/AndroidManifest.xml
+++ b/VRHackathons/sxr-sociobowl/app/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.sxrbullet.BulletSampleActivity"
             android:screenOrientation="landscape"

--- a/common.gradle
+++ b/common.gradle
@@ -1,5 +1,3 @@
-project.ext.hasBackend = false
-
 if (file("../../../extra_properties.gradle").exists()) {
     apply from: '../../../extra_properties.gradle'
 }
@@ -30,14 +28,11 @@ android {
         debug {
             debuggable = true
             jniDebuggable = true
-            resValue 'string', 'app_name', System.getProperty("appName")
         }
         release {
             signingConfig signingConfigs.debug
-            resValue 'string', 'app_name', System.getProperty("appName")
         }
     }
-
 
     flavorDimensions "vr"
 
@@ -46,52 +41,50 @@ android {
             dimension "vr"
             applicationIdSuffix ".monoscopic"
             versionNameSuffix "-monoscopic"
+            resValue 'string', 'app_name', System.getProperty("appName")+"-monoscopic"
+
+            ndk {
+                if (project.hasProperty("SXRSDK_ABI_FILTER")) {
+                    abiFilters project.property("SXRSDK_ABI_FILTER")
+                } else {
+                    abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
+                }
+            }
         }
         daydream {
             dimension "vr"
             applicationIdSuffix ".daydream"
             versionNameSuffix "-daydream"
-        }
-        vr_only {
-            dimension "vr"
-            applicationIdSuffix ".vr_only"
-            versionNameSuffix "-vr_only"
-            manifestPlaceholders = [vrMetaData:'<meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>']
-        }
-        ar {
-            dimension "vr"
-            applicationIdSuffix ".ar"
-            versionNameSuffix "-ar"
-            manifestPlaceholders = [vrMetaData:'<meta-data android:name="com.samsung.android.sxr.application.type" android:value="ar"/>']
-        }
-    }
+            resValue 'string', 'app_name', System.getProperty("appName")+"-daydream"
 
-    variantFilter { variant ->
-        def names = variant.flavors*.name
-        if (names.contains("monoscopic") && !(project.hasProperty("backend_monoscopic") && project.property("backend_monoscopic")) ) {
-            setIgnore(true)
-	}
-        if (names.contains("daydream") && !(project.hasProperty("backend_daydream") && project.property("backend_daydream")) ) {
-            setIgnore(true)
-	}
-        if (names.contains("vr_only") && !(project.hasProperty("backend_oculus") && project.property("backend_oculus")) ) {
-            setIgnore(true)
-	}
-        if (names.contains("ar") && !(project.hasProperty("sxr_adapter") && project.property("sxr_adapter")) ) {
-            setIgnore(true)
-	}
+            ndk {
+                if (project.hasProperty("SXRSDK_ABI_FILTER")) {
+                    abiFilters project.property("SXRSDK_ABI_FILTER")
+                } else {
+                    abiFilters "armeabi-v7a", "arm64-v8a"
+                }
+            }
+        }
+        oculus {
+            dimension "vr"
+            applicationIdSuffix ".oculus"
+            versionNameSuffix "-oculus"
+            manifestPlaceholders = [vrMetaData:'<meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>']
+            resValue 'string', 'app_name', System.getProperty("appName")+"-oculus"
+
+            ndk {
+                if (project.hasProperty("SXRSDK_ABI_FILTER")) {
+                    abiFilters project.property("SXRSDK_ABI_FILTER")
+                } else {
+                    abiFilters "armeabi-v7a", "arm64-v8a"
+                }
+            }
+        }
     }
 
     defaultConfig {
         minSdkVersion 23
         targetSdkVersion 23
-        ndk {
-            if (project.hasProperty("SXRSDK_ABI_FILTER")) {
-                abiFilters project.property("SXRSDK_ABI_FILTER")
-            } else {
-                abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
-            }
-        }
     }
 
     applicationVariants.all { variant ->
@@ -100,7 +93,6 @@ android {
         }
     }
 
-    // ignore the x86 files from the google vr libraries
     packagingOptions {
         pickFirst 'lib/*/libc++_shared.so'
     }
@@ -126,29 +118,10 @@ file("../../..").eachDir {
     }
 }
 
-/*
-To use local dependencies add the following line in a global gradle properties file
-eg. ~/.gradle/gradle.properties:
-
-useLocalDependencies=true
-
- */
 ext.sxrVersion = '4.0.1-SNAPSHOT'
 project.ext.daydreamVersion = '1.130.0'
 project.ext.jomlVersion = "1.9.3-SNAPSHOT"
 project.ext.gsonVersion = '2.8.2'
-
-if (!project.ext.hasBackend) {
-    project.ext.backend_monoscopic = true
-}
-
-if (project.hasProperty("backend_monoscopic")) {
-    project.ext.backend_monoscopic = project.property("backend_monoscopic")
-} else if (project.hasProperty("backend_daydream")) {
-    project.ext.backend_daydream = project.property("backend_daydream")
-} else if (project.hasProperty("backend_oculus")) {
-    project.ext.backend_oculus = project.property("backend_oculus")
-}
 
 dependencies {
     implementation "com.google.code.gson:gson:$gsonVersion"
@@ -165,45 +138,36 @@ dependencies {
         implementation "com.samsungxr:sxrsdk:$sxrVersion"
     }
 
-    if (project.hasProperty("backend_monoscopic") && project.property("backend_monoscopic")) {
-        if (project.hasProperty("useLocalDependencies") && project.useLocalDependencies) {
-            if (findProject(':backend_monoscopic')) {
-                implementation project(':backend_monoscopic')
-            } else {
-                debugImplementation(name: 'backend_monoscopic-debug', ext: 'aar')
-                releaseImplementation(name: 'backend_monoscopic-release', ext: 'aar')
-            }
+    if (project.hasProperty("useLocalDependencies") && project.useLocalDependencies) {
+        if (findProject(':backend_monoscopic')) {
+            monoscopicImplementation project(':backend_monoscopic')
         } else {
-            implementation "com.samsungxr:backend_monoscopic:$sxrVersion"
+            monoscopicImplementation(':backend_monoscopic-release@aar')
         }
+    } else {
+        monoscopicImplementation "com.samsungxr:backend_monoscopic:$sxrVersion"
     }
 
-    if (project.hasProperty("backend_daydream") && project.property("backend_daydream")) {
-        if (project.hasProperty("useLocalDependencies") && project.useLocalDependencies) {
-            if (findProject(':backend_daydream')) {
-                implementation project(':backend_daydream')
-            } else {
-                debugImplementation(name: 'backend_daydream-debug', ext: 'aar')
-                releaseImplementation(name: 'backend_daydream-release', ext: 'aar')
-            }
+    if (project.hasProperty("useLocalDependencies") && project.useLocalDependencies) {
+        if (findProject(':backend_daydream')) {
+            daydreamImplementation project(':backend_daydream')
         } else {
-            implementation "com.samsungxr:backend_daydream:$sxrVersion"
+            daydreamImplementation(':backend_daydream-release@aar')
         }
-        implementation "com.google.vr:sdk-base:${daydreamVersion}"
-        implementation "com.google.vr:sdk-controller:${daydreamVersion}"
+    } else {
+        daydreamImplementation "com.samsungxr:backend_daydream:$sxrVersion"
     }
+    daydreamImplementation "com.google.vr:sdk-base:${daydreamVersion}"
+    daydreamImplementation "com.google.vr:sdk-controller:${daydreamVersion}"
 
-    if (project.hasProperty("backend_oculus") && project.property("backend_oculus")) {
-        if (project.hasProperty("useLocalDependencies") && project.useLocalDependencies) {
-            if (findProject(':backend_oculus')) {
-                implementation project(':backend_oculus')
-            } else {
-                debugImplementation(name: 'backend_oculus-debug', ext: 'aar')
-                releaseImplementation(name: 'backend_oculus-release', ext: 'aar')
-            }
+    if (project.hasProperty("useLocalDependencies") && project.useLocalDependencies) {
+        if (findProject(':backend_oculus')) {
+            oculusImplementation project(':backend_oculus')
         } else {
-            implementation "com.samsungxr:backend_oculus:$sxrVersion"
+            oculusImplementation(':backend_oculus-release@aar')
         }
+    } else {
+        oculusImplementation "com.samsungxr:backend_oculus:$sxrVersion"
     }
 }
 

--- a/common.gradle
+++ b/common.gradle
@@ -38,6 +38,50 @@ android {
         }
     }
 
+
+    flavorDimensions "vr"
+
+    productFlavors {
+        monoscopic {
+            dimension "vr"
+            applicationIdSuffix ".monoscopic"
+            versionNameSuffix "-monoscopic"
+        }
+        daydream {
+            dimension "vr"
+            applicationIdSuffix ".daydream"
+            versionNameSuffix "-daydream"
+        }
+        vr_only {
+            dimension "vr"
+            applicationIdSuffix ".vr_only"
+            versionNameSuffix "-vr_only"
+            manifestPlaceholders = [vrMetaData:'<meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>']
+        }
+        ar {
+            dimension "vr"
+            applicationIdSuffix ".ar"
+            versionNameSuffix "-ar"
+            manifestPlaceholders = [vrMetaData:'<meta-data android:name="com.samsung.android.sxr.application.type" android:value="ar"/>']
+        }
+    }
+
+    variantFilter { variant ->
+        def names = variant.flavors*.name
+        if (names.contains("monoscopic") && !(project.hasProperty("backend_monoscopic") && project.property("backend_monoscopic")) ) {
+            setIgnore(true)
+	}
+        if (names.contains("daydream") && !(project.hasProperty("backend_daydream") && project.property("backend_daydream")) ) {
+            setIgnore(true)
+	}
+        if (names.contains("vr_only") && !(project.hasProperty("backend_oculus") && project.property("backend_oculus")) ) {
+            setIgnore(true)
+	}
+        if (names.contains("ar") && !(project.hasProperty("sxr_adapter") && project.property("sxr_adapter")) ) {
+            setIgnore(true)
+	}
+    }
+
     defaultConfig {
         minSdkVersion 23
         targetSdkVersion 23

--- a/disabled-sxr-video/app/src/main/AndroidManifest.xml
+++ b/disabled-sxr-video/app/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
         android:allowBackup="true"
         android:icon="@drawable/sxr_192x192"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.video.VideoActivity"
             android:screenOrientation="landscape"

--- a/sxr-360photo/app/src/main/AndroidManifest.xml
+++ b/sxr-360photo/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
       <application android:label="@string/app_name" 
                    android:icon="@drawable/ic_launcher">
 
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity android:name="Minimal360PhotoActivity"
                   android:screenOrientation="landscape"
                   android:launchMode="singleTask"

--- a/sxr-360video/app/src/main/AndroidManifest.xml
+++ b/sxr-360video/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application android:label="@string/app_name" android:icon="@drawable/ic_launcher">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity android:name="Minimal360VideoActivity"
                   android:screenOrientation="landscape"
                   android:launchMode="singleTask"

--- a/sxr-3dcursor-simple/app/src/main/AndroidManifest.xml
+++ b/sxr-3dcursor-simple/app/src/main/AndroidManifest.xml
@@ -28,9 +28,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name">
-        <meta-data
-            android:name="com.samsung.android.vr.application.mode"
-            android:value="vr_only"/>
+	${vrMetaData}
         <activity
             android:name="com.samsungxr.io.cursorsimple.CursorActivity"
             android:label="@string/app_name"

--- a/sxr-3dcursor/app/src/main/AndroidManifest.xml
+++ b/sxr-3dcursor/app/src/main/AndroidManifest.xml
@@ -28,9 +28,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name">
-        <meta-data
-            android:name="com.samsung.android.vr.application.mode"
-            android:value="vr_only"/>
+        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only" />
         <activity
             android:name=".CursorActivity"
             android:label="@string/app_name"

--- a/sxr-accessibility/app/src/main/AndroidManifest.xml
+++ b/sxr-accessibility/app/src/main/AndroidManifest.xml
@@ -12,9 +12,7 @@
     <application
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">
-         <meta-data
-             android:name="com.samsung.android.vr.application.mode"
-            android:value="vr_only" /> 
+	${vrMetaData}
 
         <activity
             android:name="com.samsung.accessibility.main.MainActivity"

--- a/sxr-arcore/app/src/main/AndroidManifest.xml
+++ b/sxr-arcore/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
         android:allowBackup="true"
         android:icon="@drawable/sxr_192x192"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.arcore.simplesample.SampleActivity"
             android:screenOrientation="landscape"

--- a/sxr-avatar/app/src/main/AndroidManifest.xml
+++ b/sxr-avatar/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:allowBackup="true"
         android:icon="@drawable/sxr_192x192"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.avatardemo.AvatarActivity"
             android:screenOrientation="landscape"

--- a/sxr-blurfilter/app/src/main/AndroidManifest.xml
+++ b/sxr-blurfilter/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:allowBackup="true"
         android:label="@string/app_name">
 
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
 
         <activity
             android:name="com.samsungxr.blurfilter.TestActivity"

--- a/sxr-bullet/app/src/main/AndroidManifest.xml
+++ b/sxr-bullet/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.sxrbullet.BulletSampleActivity"
             android:screenOrientation="landscape"

--- a/sxr-camera2renderscript/app/src/main/AndroidManifest.xml
+++ b/sxr-camera2renderscript/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">
         
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/> 
+        ${vrMetaData} 
         <activity
             android:name="com.samsungxr.sxrcamera2renderscript.Camera2RenderscriptActivity"
             android:screenOrientation="landscape"

--- a/sxr-cardboard-audio/app/src/main/AndroidManifest.xml
+++ b/sxr-cardboard-audio/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
 
 
      <application android:label="@string/app_name" android:icon="@drawable/ic_launcher">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity android:name="SpatialAudioActivity"
                   android:screenOrientation="landscape"
                   android:launchMode="singleTask"

--- a/sxr-complexscene/app/src/main/AndroidManifest.xml
+++ b/sxr-complexscene/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.complexscene.SampleActivity"
             android:screenOrientation="landscape"

--- a/sxr-controller/app/src/main/AndroidManifest.xml
+++ b/sxr-controller/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.sample.controller.SampleActivity"
             android:screenOrientation="landscape"

--- a/sxr-controls/app/src/main/AndroidManifest.xml
+++ b/sxr-controls/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
         android:allowBackup="true"
         android:icon="@drawable/sxr_192x192"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.controls.MainActivity"
             android:label="@string/app_name"

--- a/sxr-cubemap/app/src/main/AndroidManifest.xml
+++ b/sxr-cubemap/app/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
         android:icon="@drawable/icon"
         android:label="@string/app_name"
         android:theme="@style/SXRfAppTheme" >
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.cubemap.CubemapActivity"
             android:screenOrientation="landscape"

--- a/sxr-events/app/src/main/AndroidManifest.xml
+++ b/sxr-events/app/src/main/AndroidManifest.xml
@@ -12,9 +12,7 @@
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name">
-        <meta-data
-            android:name="com.samsung.android.vr.application.mode"
-            android:value="vr_only" />
+	${vrMetaData}
 
         <activity
             android:name="EventsActivity"

--- a/sxr-eyepicking/app/src/main/AndroidManifest.xml
+++ b/sxr-eyepicking/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
         android:allowBackup="true"
         android:icon="@drawable/bunny"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.sxreyepicking.SampleActivity"
             android:screenOrientation="landscape"

--- a/sxr-gamepad/app/src/main/AndroidManifest.xml
+++ b/sxr-gamepad/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <!-- If you uncomment "vr_only" above, please put android:screenOrientation="landscape" in activity to run correctly.
         Otherwise you should hold your device on landscape by hand-->
         <activity

--- a/sxr-immersivepedia/app/src/main/AndroidManifest.xml
+++ b/sxr-immersivepedia/app/src/main/AndroidManifest.xml
@@ -15,9 +15,7 @@
         android:icon="@drawable/icon"
         android:label="@string/app_name"
         android:theme="@style/SXRfAppTheme" >
-        <meta-data
-            android:name="com.samsung.android.vr.application.mode"
-            android:value="vr_only" />
+	${vrMetaData}
 
         <activity
             android:name="com.samsungxr.immersivepedia.MainActivity"

--- a/sxr-javascript/app/src/main/AndroidManifest.xml
+++ b/sxr-javascript/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
      <application android:label="@string/app_name" android:icon="@drawable/gearvr_script">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity android:name="GearVRJavascriptActivity"
                   android:screenOrientation="landscape"
                   android:launchMode="singleTask"

--- a/sxr-keyboard/app/src/main/AndroidManifest.xml
+++ b/sxr-keyboard/app/src/main/AndroidManifest.xml
@@ -12,8 +12,7 @@
         android:icon="@drawable/sxr_192x192"
         android:label="@string/app_name">
 
-     <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only" /> 
-
+	${vrMetaData}
 
         <activity
             android:name="com.samsungxr.keyboard.main.MainActivity"

--- a/sxr-keyboardview/app/src/main/AndroidManifest.xml
+++ b/sxr-keyboardview/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:icon="@drawable/ic_launcher"
         android:label="Contact"
          >
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity android:name="MainActivity"
                   android:screenOrientation="landscape"
                   android:launchMode="singleTask"

--- a/sxr-meshanimation/app/src/main/AndroidManifest.xml
+++ b/sxr-meshanimation/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:allowBackup="true"
         android:icon="@drawable/sxr_192x192"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.sxrmeshanimation.MeshAnimationActivity"
             android:screenOrientation="landscape"

--- a/sxr-morph/app/src/main/AndroidManifest.xml
+++ b/sxr-morph/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         android:allowBackup="true"
         android:icon="@drawable/sxr_192x192"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.morph.SampleActivity"
             android:screenOrientation="landscape"

--- a/sxr-multilight/app/src/main/AndroidManifest.xml
+++ b/sxr-multilight/app/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
         android:allowBackup="true"
         android:icon="@drawable/icon"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.multilight.MultiLightActivity"
             android:screenOrientation="landscape"

--- a/sxr-outline/app/src/main/AndroidManifest.xml
+++ b/sxr-outline/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         android:allowBackup="true"
         android:icon="@drawable/sxr_192x192"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.sxroutline.OutlineActivity"
             android:screenOrientation="landscape"

--- a/sxr-particles/app/src/main/AndroidManifest.xml
+++ b/sxr-particles/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         android:allowBackup="true"
         android:icon="@drawable/sxr_192x192"
         android:label="sxr-particles">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.particles.SampleActivity"
             android:screenOrientation="landscape"

--- a/sxr-performance/app/src/main/AndroidManifest.xml
+++ b/sxr-performance/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.performance.TestActivity"
             android:label="@string/app_name"

--- a/sxr-physicsload/app/src/main/AndroidManifest.xml
+++ b/sxr-physicsload/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.physicsload.MainActivity"
             android:screenOrientation="landscape"

--- a/sxr-polyline/app/src/main/AndroidManifest.xml
+++ b/sxr-polyline/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
     <application
         android:allowBackup="true"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.polyline.SampleActivity"
             android:screenOrientation="landscape"

--- a/sxr-ragdoll/app/src/main/AndroidManifest.xml
+++ b/sxr-ragdoll/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.ragdoll.RagdollActivity"
             android:screenOrientation="landscape"

--- a/sxr-remote-scripting/app/src/main/AndroidManifest.xml
+++ b/sxr-remote-scripting/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application android:label="@string/app_name" android:icon="@drawable/ic_launcher">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity android:name="GearVRScripting"
                   android:icon="@drawable/sxr_192x192"
                   android:screenOrientation="landscape"

--- a/sxr-renderableview/app/src/main/AndroidManifest.xml
+++ b/sxr-renderableview/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:hardwareAccelerated="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity android:name="MainActivity"
                   android:screenOrientation="landscape"
                   android:launchMode="singleTask"

--- a/sxr-rendertotexture/app/src/main/AndroidManifest.xml
+++ b/sxr-rendertotexture/app/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
         android:allowBackup="true"
         android:icon="@drawable/sxr_192x192"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.rendertotexture.RenderToTextureActivity"
             android:screenOrientation="landscape"

--- a/sxr-sceneobjects/app/src/main/AndroidManifest.xml
+++ b/sxr-sceneobjects/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
     <uses-feature android:name="android.hardware.camera"/>
     
     <application android:label="@string/app_name" android:icon="@drawable/ic_launcher">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity android:name="NodeActivity"
                   android:screenOrientation="landscape"
                   android:launchMode="singleTask"

--- a/sxr-shadows/app/src/main/AndroidManifest.xml
+++ b/sxr-shadows/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:icon="@drawable/sxr_192x192"
         android:label="@string/app_name">
 
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
 
         <activity
             android:name="com.samsungxr.sxrshadowssample.ShadowsActivity"

--- a/sxr-simplephysics/app/src/main/AndroidManifest.xml
+++ b/sxr-simplephysics/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.simplephysics.main.MainActivity"
             android:screenOrientation="landscape"

--- a/sxr-simplesample/app/src/main/AndroidManifest.xml
+++ b/sxr-simplesample/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         android:allowBackup="true"
         android:icon="@drawable/sxr_192x192"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.simplesample.SampleActivity"
             android:screenOrientation="landscape"

--- a/sxr-solarsystem/app/src/main/AndroidManifest.xml
+++ b/sxr-solarsystem/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.solarsystem.SolarActivity"
             android:screenOrientation="landscape"

--- a/sxr-switch/app/src/main/AndroidManifest.xml
+++ b/sxr-switch/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
         android:allowBackup="true"
         android:icon="@drawable/bunny"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.sxrswitch.SampleActivity"
             android:screenOrientation="landscape"

--- a/sxr-tutorial-lesson2/app/src/main/AndroidManifest.xml
+++ b/sxr-tutorial-lesson2/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
         android:allowBackup="true"
         android:icon="@drawable/icon"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.balloons.BalloonActivity"
             android:screenOrientation="landscape"

--- a/sxr-tutorial-lesson3/app/src/main/AndroidManifest.xml
+++ b/sxr-tutorial-lesson3/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
         android:allowBackup="true"
         android:icon="@drawable/icon"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.balloons.BalloonActivity"
             android:screenOrientation="landscape"

--- a/sxr-tutorial-lesson4/app/src/main/AndroidManifest.xml
+++ b/sxr-tutorial-lesson4/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
         android:allowBackup="true"
         android:icon="@drawable/icon"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.balloons.BalloonActivity"
             android:screenOrientation="landscape"

--- a/sxr-tutorial-lesson5/app/src/main/AndroidManifest.xml
+++ b/sxr-tutorial-lesson5/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
         android:allowBackup="true"
         android:icon="@drawable/icon"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.balloons.BalloonActivity"
             android:screenOrientation="landscape"

--- a/sxr-tutorial-lesson6/app/src/main/AndroidManifest.xml
+++ b/sxr-tutorial-lesson6/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
         android:allowBackup="true"
         android:icon="@drawable/icon"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.balloons.BalloonActivity"
             android:screenOrientation="landscape"

--- a/sxr-videoplayer/app/src/main/AndroidManifest.xml
+++ b/sxr-videoplayer/app/src/main/AndroidManifest.xml
@@ -26,9 +26,7 @@
         android:name=".VideoPlayerApp"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">
-        <meta-data
-            android:name="com.samsung.android.vr.application.mode"
-            android:value="vr_only" />
+	${vrMetaData}
         <activity
             android:name=".VideoPlayerActivity"
             android:label="@string/app_name"

--- a/sxr-vuforia/app/src/main/AndroidManifest.xml
+++ b/sxr-vuforia/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
         android:allowBackup="true"
         android:icon="@drawable/icon"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.vuforiasample.VuforiaSampleActivity"
             android:screenOrientation="landscape"

--- a/sxr-widgetlib-viewer/app/src/main/AndroidManifest.xml
+++ b/sxr-widgetlib-viewer/app/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
         android:icon="@drawable/sxr_192x192"
         android:allowBackup="true"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only" />
+	${vrMetaData}
         <activity
             android:name="com.samsungxr.widgetlibviewer.SXRWidgetLibViewer"
             android:screenOrientation="landscape"

--- a/sxr-x3d-demo/app/src/main/AndroidManifest.xml
+++ b/sxr-x3d-demo/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
         android:allowBackup="true"
         android:icon="@drawable/icon"
         android:label="@string/app_name">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name="com.samsungxr.x3ddemo.X3DparserActivity"
             android:screenOrientation="landscape"

--- a/template/SXRApplication/app/src/main/AndroidManifest.xml
+++ b/template/SXRApplication/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         tools:replace="android:icon">
 
         <!-- meta-data for GearVR comment this for DayDream testing-->
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
 
         <activity
             android:name=".MainActivity"

--- a/tutorials/tutorial_1_simple_app/app/src/main/AndroidManifest.xml
+++ b/tutorials/tutorial_1_simple_app/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         tools:replace="android:icon">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTask"

--- a/tutorials/tutorial_2_materials/app/src/main/AndroidManifest.xml
+++ b/tutorials/tutorial_2_materials/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         tools:replace="android:icon">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTask"

--- a/tutorials/tutorial_3_model_animation/app/src/main/AndroidManifest.xml
+++ b/tutorials/tutorial_3_model_animation/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         tools:replace="android:icon">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTask"

--- a/tutorials/tutorial_4_animation/app/src/main/AndroidManifest.xml
+++ b/tutorials/tutorial_4_animation/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         tools:replace="android:icon">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTask"

--- a/tutorials/tutorial_5_controller/app/src/main/AndroidManifest.xml
+++ b/tutorials/tutorial_5_controller/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         tools:replace="android:icon">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTask"

--- a/tutorials/tutorial_6_vr_video/app/src/main/AndroidManifest.xml
+++ b/tutorials/tutorial_6_vr_video/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         tools:replace="android:icon">
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTask"

--- a/tutorials/tutorial_7_component/app/src/main/AndroidManifest.xml
+++ b/tutorials/tutorial_7_component/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         tools:replace="android:icon">
 
         <!-- meta-data for GearVR comment this for DayDream testing-->
-        <meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        ${vrMetaData}
 
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
Use oculus as a name instead of vr_only
Drops our backend_xyz=true|false notion; just select build variant in AS; we no longer support including support for multiple runtimes in the same apk

Simply put you choose to build a demo for a particular runtime only; pick the one from AS's build variant pane.

On top of https://github.com/sxrsdk/sxrsdk-demos/pull/13

SXR-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>