### PR TITLE
sxr-arcore: add ARCore as explicit dependency

### DIFF
--- a/sxr-arcore/app/build.gradle
+++ b/sxr-arcore/app/build.gradle
@@ -24,11 +24,17 @@ android {
 }
 
 dependencies {
+    // ARCore library
+    implementation "com.google.ar:core:1.5.0"
     implementation 'com.android.support:support-v4:27.0.2'
 
     if (project.hasProperty("useLocalDependencies") && project.useLocalDependencies) {
-        debugImplementation(name: 'MixedReality-debug', ext: 'aar')
-        releaseImplementation(name: 'MixedReality-release', ext: 'aar')
+        if (findProject(':MixedReality')) {
+            implementation project(':MixedReality')
+        } else {
+            debugImplementation(name: 'MixedReality-debug', ext: 'aar')
+            releaseImplementation(name: 'MixedReality-release', ext: 'aar')
+        }
     } else {
         implementation "com.samsungxr:MixedReality:$sxrVersion"
     }


### PR DESCRIPTION
It is necessary to put the ARCore as explicit dependency just to avoid the errors below in run time, once MixedReality doesn't include ARCore on its package.

2019-01-10 09:54:29.010 12251-12285/com.samsungxr.arcore.simplesample.monoscopic W/System.err: java.lang.reflect.InvocationTargetException
2019-01-10 09:54:29.011 12251-12285/com.samsungxr.arcore.simplesample.monoscopic W/System.err: Caused by: java.lang.ClassNotFoundException: Didn't find class "com.google.ar.core.Anchor$CloudAnchorState" on path: DexPathList[[zip file "/data/app/com.samsungxr.arcore.simplesample.monoscopic-8nctkn3eSnUEvkQEUtjN5A==/base.apk" ...
2019-01-10 09:54:29.011 12251-12285/com.samsungxr.arcore.simplesample.monoscopic W/System.err:     at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:93)

SXR-DCO-1.0-Signed-off-by: Afonso Costa <afonso.j@samsung.com>