### PR TITLE
sxr-morph: position character so it is visible

### DIFF
--- a/sxr-morph/app/src/main/java/com/samsungxr/morph/SampleActivity.java
+++ b/sxr-morph/app/src/main/java/com/samsungxr/morph/SampleActivity.java
@@ -75,7 +75,7 @@ public class SampleActivity extends SXRActivity {
             try
             {
                 addModeltoScene(filePath, new Vector3f(0.05f,0.05f,0.05f),
-                        new Vector3f(0, -8.5f, -6.5f));
+                        new Vector3f(0, -2, -10));
             }
             catch (IOException ex)
             {


### PR DESCRIPTION
After PR# 109 in sxrsdk, the character is positioned so it is not completely visible. This PR fixes that.

SXR DCO signed off by: Nola Donato nola.donato@samsung.com