### PR TITLE
sxr-cubemap: disable the head model to ensure camera is right at the center of the cubemap

### DIFF
--- a/sxr-cubemap/app/src/main/assets/sxr.xml
+++ b/sxr-cubemap/app/src/main/assets/sxr.xml
@@ -54,9 +54,9 @@
             resolveDepth="false" />
 
         <head-model-parms
-            eyeHeight="DEFAULT"
-            headModelDepth="DEFAULT"
-            headModelHeight="DEFAULT"
+            eyeHeight="0"
+            headModelDepth="0"
+            headModelHeight="0"
             interpupillaryDistance="DEFAULT" />
     </vr-app-settings>
 


### PR DESCRIPTION
Otherwise there could be visual distortion.

SXR-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>