### PR TITLE
sxr-arpet: Add info about Cloud Anchor API key

### DIFF
--- a/sxr-arpet/README.md
+++ b/sxr-arpet/README.md
@@ -1,0 +1,18 @@
+# SXR-ARPET
+A pet experience in Augmented Reality (AR).
+
+## Main features
+* Plane detection and point cloud to show the AR detected points to compose the plane.
+* Share AR experience using Cloud Anchors and connect several devices using Bluetooth.
+* Physics simulation working with AR.
+* 3D models, animations and Android views in AR environment.
+* Capture and share screen images.
+
+## Configure Cloud Anchor API Key
+This application uses [Google Cloud Anchor service](https://developers.google.com/ar/develop/java/cloud-anchors/quickstart-android) to share the AR experience between several devices. For this, we need to create and export a Cloud Anchor API key, which can be obtained in [Google Cloud Platform](https://console.cloud.google.com/apis/library/arcorecloudanchor.googleapis.com).
+
+Once you have the key, configure it in your global `gradle.properties` file using the variable name *cloudAnchorApiKey* (like this: *cloudAnchorApiKey=XXXX, where XXXX is your API key*) and build the application.
+
+The sharing experience uses Bluetooth to make the communication between the devices. Don't forget to turn it on before starting the sharing mode.
+
+After that, you are able to start the sharing anchor mode. Enjoy it and have fun!

--- a/sxr-arpet/app/build.gradle
+++ b/sxr-arpet/app/build.gradle
@@ -32,6 +32,7 @@ def getPropertyOrDefault(propertyName, defaultValue) {
     return project.hasProperty(propertyName) ? project.property(propertyName) : defaultValue
 }
 
+// See README.md file to get info about how to obtain and set this API key
 def GOOGLE_CLOUD_ANCHOR_KEY_NAME = "com.google.android.ar.API_KEY"
 
 android {


### PR DESCRIPTION
Create a README file to put info about how to get/configure the Cloud Anchor API key used in Sharing Anchor mode.

SXR-DCO-1.0-Signed-off-by: Afonso Costa <afonso.j@samsung.com>