### PR TITLE
sxr-complexscene: specify a layer for the cursor object

### DIFF
--- a/sxr-complexscene/app/src/main/AndroidManifest.xml
+++ b/sxr-complexscene/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     android:versionName="1.0" >
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     
     <application

--- a/sxr-complexscene/app/src/main/assets/sxr.xml
+++ b/sxr-complexscene/app/src/main/assets/sxr.xml
@@ -29,7 +29,8 @@
         framebufferPixelsWide="DEFAULT"
         showLoadingIcon="true"
         useProtectedFramebuffer="false"
-        useSrgbFramebuffer="false" >
+        useSrgbFramebuffer="false"
+        useCursorLayer="true">
 
         <mono-mode-parms
             monoFullScreen="false"

--- a/sxr-complexscene/app/src/main/java/com/samsungxr/complexscene/SampleActivity.java
+++ b/sxr-complexscene/app/src/main/java/com/samsungxr/complexscene/SampleActivity.java
@@ -27,7 +27,7 @@ public class SampleActivity extends SXRActivity {
     protected void onCreate(Bundle icicle) {
         super.onCreate(icicle);
         mMain = new SampleMain();
-        setMain(mMain);
+        setMain(mMain, "sxr.xml");
     }
 
 }

--- a/sxr-complexscene/app/src/main/java/com/samsungxr/complexscene/SampleMain.java
+++ b/sxr-complexscene/app/src/main/java/com/samsungxr/complexscene/SampleMain.java
@@ -55,7 +55,7 @@ public class SampleMain extends SXRMain {
         cursor.getRenderData()
                 .setRenderingOrder(SXRRenderData.SXRRenderingOrder.OVERLAY)
                 .setDepthTest(false)
-                .setRenderingOrder(CURSOR_RENDER_ORDER);
+                .setRenderingOrder(CURSOR_RENDER_ORDER).setLayer(SXRRenderData.LayerType.HeadLocked);
         sxrContext.getMainScene().getMainCameraRig().addChildObject(cursor);
 
         try {
@@ -68,17 +68,16 @@ public class SampleMain extends SXRMain {
             for (int x=-OBJECTS_CNT; x<=OBJECTS_CNT; ++x) {
                 for (int y=-OBJECTS_CNT; y<=OBJECTS_CNT; ++y) {
                     SXRNode sceneObject = getColorMesh(1.0f, mesh);
+                    sceneObject.setName("bunny"+x+""+y);
                     sceneObject.getTransform().setPosition(1.0f*x, 1.0f*y, -7.5f);
                     sceneObject.getTransform().setScale(0.5f, 0.5f, 1.0f);
                     scene.addNode(sceneObject);
                 }
+            }
 
-        }
         } catch (Exception e) {
             e.printStackTrace();
         }
-
-
     }
 
     private SXRNode getColorMesh(float scale, SXRMesh mesh) {


### PR DESCRIPTION
Depends on: https://github.com/sxrsdk/sxrsdk/pull/122

For backends adapter where layers are not supported, the cursor will be rendered to the normal eye buffer.

SXR-DCO-1.0-Signed-off-by: Mihail Marinov <m.marinov@samsung.com>