### PR TITLE
Fix package name

### DIFF
--- a/sxr-complexscene/app/src/main/AndroidManifest.xml
+++ b/sxr-complexscene/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.samsungxr.complexsScene"
+    package="com.samsungxr.complexscene"
     android:versionCode="1"
     android:versionName="1.0" >
 


### PR DESCRIPTION
Package name in AndroidManifest.xml should match Java package name
- - -
SXR-DCO-1.0-Signed-off-by: Dmitriy Vasilev d.vasilev@samsung.com